### PR TITLE
Add common extensions to markdown parser

### DIFF
--- a/internal/pkg/mark2web/service.go
+++ b/internal/pkg/mark2web/service.go
@@ -17,15 +17,13 @@ import (
 type Service struct {
 	Logger *log.Logger
 	DB     db.DB
-	psr    *parser.Parser
 }
+
+var markdownExtensions = parser.CommonExtensions | parser.AutoHeadingIDs
 
 func NewService(opts ...func(*Service) error) (*Service, error) {
 	log.Traceln("creating a new service")
-	extensions := parser.CommonExtensions | parser.AutoHeadingIDs
-	psr := parser.NewWithExtensions(extensions)
-
-	s := Service{psr: psr}
+	s := Service{}
 
 	// set sensible defaults
 	s.Logger = log.New()
@@ -51,7 +49,8 @@ func (s *Service) HTMLFor(ID string) ([]byte, error) {
 // MarkdownToURL generates a URL for the markdown,
 // creates a mapping of the URL to the markdown and returns the URL
 func (s *Service) MarkdownToURL(md []byte, host string) (string, error) {
-	HTMLEquiv := markdownToHTML(md, s.psr)
+	psr := parser.NewWithExtensions(markdownExtensions)
+	HTMLEquiv := markdownToHTML(md, psr)
 	path := shasumOf(HTMLEquiv)
 	// Create mapping
 	err := s.DB.Save(path, HTMLEquiv)

--- a/internal/pkg/mark2web/service_test.go
+++ b/internal/pkg/mark2web/service_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"io/ioutil"
 	"testing"
+
+	"github.com/gomarkdown/markdown/parser"
 )
 
 func TestShasumOf(t *testing.T) {
@@ -27,7 +29,10 @@ func TestMarkdownToHTML(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	gotHTML := markdownToHTML(testMarkdown)
+	extensions := parser.CommonExtensions
+	psr := parser.NewWithExtensions(extensions)
+
+	gotHTML := markdownToHTML(testMarkdown, psr)
 	if !bytes.Equal(testHTML, gotHTML) {
 		t.Fatalf("Rendered HTML does not match expected")
 	}

--- a/internal/pkg/web/handler_test.go
+++ b/internal/pkg/web/handler_test.go
@@ -43,7 +43,7 @@ func TestE2E(t *testing.T) {
 	// Get HTML
 	id := getLastPath(string(gotURL))
 
-	expectedHTMLBytes := []byte("<h1>Markdown Data</h1>")
+	expectedHTMLBytes := []byte(`<h1 id="markdown-data">Markdown Data</h1>`)
 	req = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/%s", id), nil)
 	rr = httptest.NewRecorder()
 


### PR DESCRIPTION
- NoIntraEmphasis: Ignore emphasis markers inside words
- Tables
- FencedCode: Parse fenced code blocks
- Autolink: Detect embedded URLs that are not explicitly marked
- Strikethrough: Strikethrough text using ~~test~~
- SpaceHeadings: Be strict about prefix heading rules
- HeadingIDs: specify heading IDs  with {#id}
- BackslashLineBreak: Translate trailing backslashes into line breaks
- DefinitionLists: Parse definition lists
- MathJax